### PR TITLE
Abstract zip frames logic into seperate Kinoscan Class

### DIFF
--- a/lib/kinoscan.rb
+++ b/lib/kinoscan.rb
@@ -1,5 +1,6 @@
 require "kinoscan/version"
 require "kinoscan/scanner"
+require "kinoscan/zipper"
 
 require 'zip'
 require 'mini_magick'

--- a/lib/kinoscan/scanner.rb
+++ b/lib/kinoscan/scanner.rb
@@ -12,6 +12,7 @@ module Kinoscan
       @output_path = output_path
       @file_name = File.basename(image_path, ".*")
       @image = ::MiniMagick::Image.open image_path
+      @frame_paths = []
       @pixels = @image.get_pixels
       self
     end
@@ -31,7 +32,7 @@ module Kinoscan
       end
 
       puts "Finished scanning: #{@image_path}"
-      frames
+      @frame_paths
     end
 
     private
@@ -109,7 +110,7 @@ module Kinoscan
 
       output_file_name = "#{@file_name}-#{idx}.jpg"
 
-      image_file_path = "#{@output_path}/#{output_file_name}"
+      image_file_path = "./#{output_file_name}"
 
       puts "New image file path: #{image_file_path}"
 
@@ -118,6 +119,7 @@ module Kinoscan
       img = MiniMagick::Image.import_pixels(blob, new_image_width, new_image_height, 8, "rgb", "jpg")
 
       img.write(image_file_path)
+      @frame_paths << image_file_path
     end
 
   end

--- a/lib/kinoscan/scanner.rb
+++ b/lib/kinoscan/scanner.rb
@@ -30,9 +30,8 @@ module Kinoscan
         save_new_image(frame, idx)
       end
 
-      zip_frames
-
       puts "Finished scanning: #{@image_path}"
+      frames
     end
 
     private
@@ -121,24 +120,5 @@ module Kinoscan
       img.write(image_file_path)
     end
 
-    def zip_frames
-      zipfile_name = "#{@file_name}-frames.zip"
-
-      zipfile_path = "#{zipfile_name}"
-      zipfile_path = "#{@output_path}/#{zipfile_path}" if @output_path
-
-      puts "Zipping frames: #{zipfile_path}"
-      zip = Zip::File.open(zipfile_path, Zip::File::CREATE) do |zipfile|
-        (1..4).each do |id|
-          file_path = "#{@file_name}-#{id}.jpg"
-          file_path = "#{@output_path}/#{@file_name}-#{id}.jpg" if @output_path
-          zipfile.add("#{@file_name}-#{id}.jpg", file_path)
-        end
-
-        zipfile
-      end
-
-      zip
-    end
   end
 end

--- a/lib/kinoscan/zipper.rb
+++ b/lib/kinoscan/zipper.rb
@@ -1,0 +1,28 @@
+module Kinoscan
+  class Zipper
+    ZIPFILE_NAME = "kinoscan.zip"
+
+    attr_reader :frames, :output_dest
+
+    def initialize(frames:, output_dest:)
+      @frames = frames
+      @output_dest = output_dest
+    end
+
+    def call
+      zipfile_path = output_dest + ZIPFILE_NAME
+
+      zip = Zip::File.open(zipfile_path, Zip::File::CREATE) do |zipfile|
+        frames.each do |frame_path|
+          file_name = File.basename frame_path
+          zipfile.add(file_name, frame_path)
+        end
+
+        zipfile
+      end
+
+      zip
+    end
+
+  end
+end

--- a/spec/kinoscan/zipper_spec.rb
+++ b/spec/kinoscan/zipper_spec.rb
@@ -1,0 +1,16 @@
+RSpec.describe Kinoscan::Zipper do
+  let(:params) { { frames: ['./frame-1.jpg', './frame-2.jpg'], output_dest: './somewhere-out-there' } }
+  let(:zipper) { described_class.new(params) }
+
+  describe 'attributes' do
+
+    it 'has a collection of frames' do
+      expect(zipper.frames).to be_a Array
+    end
+
+    it 'has an archive destination' do
+      expect(zipper.output_dest).to be_a String
+    end
+
+  end
+end


### PR DESCRIPTION
Changes:
* Remove zip logic call from Kinoscan Scanner service
* Implement zip archival feature in Zipper class
* Spec `#initialize` method for Zipper class